### PR TITLE
Python: palindrome

### DIFF
--- a/python/strings/palindrome.py
+++ b/python/strings/palindrome.py
@@ -1,0 +1,6 @@
+def isPalindrome(str) -> bool:
+
+    reversed = ""
+    for c in str:
+        reversed += c
+    return str == reversed

--- a/python/strings/palindrome.py
+++ b/python/strings/palindrome.py
@@ -1,4 +1,6 @@
-# A string is said to be palindrome if reverse of the string is same as string. For example, “abba” is palindrome, but “abbc” is not palindrome.
+# A string is said to be palindrome if reverse of the string is same as string.
+# For example, “abba” is palindrome, but “abbc” is not palindrome.
+
 
 def palindrome(str) -> bool:
 
@@ -6,3 +8,13 @@ def palindrome(str) -> bool:
     for c in str:
         reversed = c + reversed
     return str == reversed
+
+
+def palindrome2(str) -> bool:
+    i = 0
+    length = len(str)
+    while i < length:
+        if str[i] != str[length - i]:
+            return False
+        i = i + 1
+    return True

--- a/python/strings/palindrome.py
+++ b/python/strings/palindrome.py
@@ -1,6 +1,8 @@
-def isPalindrome(str) -> bool:
+# A string is said to be palindrome if reverse of the string is same as string. For example, “abba” is palindrome, but “abbc” is not palindrome.
+
+def palindrome(str) -> bool:
 
     reversed = ""
     for c in str:
-        reversed += c
+        reversed = c + reversed
     return str == reversed

--- a/python/tests/palindrome_test.py
+++ b/python/tests/palindrome_test.py
@@ -9,3 +9,8 @@ class TestPalindromeMethods(unittest.TestCase):
         self.assertTrue(palindrome("abba"))
         self.assertFalse((palindrome("nguyennguyen")))
 
+
+    def test_palindrome2(self):
+        self.assertTrue(palindrome("abba"))
+        self.assertFalse((palindrome("nguyennguyen")))
+

--- a/python/tests/palindrome_test.py
+++ b/python/tests/palindrome_test.py
@@ -1,10 +1,11 @@
 import unittest
 
-from strings.palindrome import isPalindrome
+from strings.palindrome import palindrome
 
 
-class TestPalindrome(unittest.TestCase):
+class TestPalindromeMethods(unittest.TestCase):
 
     def test_palindrome(self):
-        self.assertEqual(isPalindrome("nguyennguyen"), False)
+        self.assertTrue(palindrome("abba"))
+        self.assertFalse((palindrome("nguyennguyen")))
 

--- a/python/tests/palindrome_test.py
+++ b/python/tests/palindrome_test.py
@@ -1,0 +1,10 @@
+import unittest
+
+from strings.palindrome import isPalindrome
+
+
+class TestPalindrome(unittest.TestCase):
+
+    def test_palindrome(self):
+        self.assertEqual(isPalindrome("nguyennguyen"), False)
+

--- a/python/tests/strings_test.py
+++ b/python/tests/strings_test.py
@@ -7,3 +7,4 @@ class TestStringMethods(unittest.TestCase):
 
     def test_stringcount(self):
         self.assertEqual(stringcount("python is great. python is awesome"), 2)
+


### PR DESCRIPTION
(This content is created via [Gittool](https://github.com/thanhnguyennguyen/lazy/blob/master/gittool.sh)) 
Python: palindrome
```
A string is said to be palindrome if reverse of the string is same as string.
 For example, “abba” is palindrome, but “abbc” is not palindrome.
```